### PR TITLE
chore!: changed import path and repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This section explains the usage of functions, structure types, and methods in th
 First, imports `reasonederror` package as follows:
 
 ```
-import "github.com/sttk-go/reasonederror"
+import "github.com/sttk/reasonederror"
 ```
 
 Next, defines structure types which represent reasons of errors.
@@ -173,35 +173,35 @@ This library supports Go 1.13 or later.
 % gvm-fav
 Now using version go1.13.15
 go version go1.13.15 darwin/amd64
-ok  	github.com/sttk-go/reasonederror	0.367s	coverage: 100.0% of statements
+ok  	github.com/sttk/reasonederror	0.361s	coverage: 100.0% of statements
 
 Now using version go1.14.15
 go version go1.14.15 darwin/amd64
-ok  	github.com/sttk-go/reasonederror	0.361s	coverage: 100.0% of statements
+ok  	github.com/sttk/reasonederror	0.363s	coverage: 100.0% of statements
 
 Now using version go1.15.15
 go version go1.15.15 darwin/amd64
-ok  	github.com/sttk-go/reasonederror	0.341s	coverage: 100.0% of statements
+ok  	github.com/sttk/reasonederror	0.344s	coverage: 100.0% of statements
 
 Now using version go1.16.15
 go version go1.16.15 darwin/amd64
-ok  	github.com/sttk-go/reasonederror	0.338s	coverage: 100.0% of statements
+ok  	github.com/sttk/reasonederror	0.336s	coverage: 100.0% of statements
 
 Now using version go1.17.13
 go version go1.17.13 darwin/amd64
-ok  	github.com/sttk-go/reasonederror	0.334s	coverage: 100.0% of statements
+ok  	github.com/sttk/reasonederror	0.334s	coverage: 100.0% of statements
 
 Now using version go1.18.10
 go version go1.18.10 darwin/amd64
-ok  	github.com/sttk-go/reasonederror	0.356s	coverage: 100.0% of statements
+ok  	github.com/sttk/reasonederror	0.366s	coverage: 100.0% of statements
 
 Now using version go1.19.10
 go version go1.19.10 darwin/amd64
-ok  	github.com/sttk-go/reasonederror	0.344s	coverage: 100.0% of statements
+ok  	github.com/sttk/reasonederror	0.343s	coverage: 100.0% of statements
 
 Now using version go1.20.5
 go version go1.20.5 darwin/amd64
-ok  	github.com/sttk-go/reasonederror	0.351s	coverage: 100.0% of statements
+ok  	github.com/sttk/reasonederror	0.348s	coverage: 100.0% of statements
 
 Back to go1.20.5
 Now using version go1.20.5
@@ -219,6 +219,6 @@ See the file LICENSE in this distribution for more details.
 [ci-img]: https://github.com/sttk/reasonederror/actions/workflows/go.yml/badge.svg?branch=main
 [ci-url]: https://github.com/sttk/reasonederror/actions
 [pkg-dev-img]: https://pkg.go.dev/badge/github.com/sttk/reasonederror.svg
-[pkg-dev-url]: https://pkg.go.dev/github.com/sttk-go/reasonederror
+[pkg-dev-url]: https://pkg.go.dev/github.com/sttk/reasonederror
 [mit-img]: https://img.shields.io/badge/license-MIT-green.svg
 [mit-url]: https://opensource.org/licenses/MIT

--- a/doc.go
+++ b/doc.go
@@ -3,7 +3,7 @@
 // See the file LICENSE in this distribution for more details.
 
 /*
-Package github.com/sttk-go/reasonederror is for error processes in Go
+Package github.com/sttk/reasonederror is for error processes in Go
 program.
 
 This package defines Err structure type which is an error type and

--- a/err_test.go
+++ b/err_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	re "github.com/sttk-go/reasonederror"
+	re "github.com/sttk/reasonederror"
 )
 
 type /* error reasons */ (
@@ -39,7 +39,7 @@ func TestNewErr_reasonIsValue(t *testing.T) {
 	assert.False(t, err.IsOk())
 	assert.True(t, err.IsNotOk())
 	assert.Equal(t, err.ReasonName(), "InvalidValue")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/reasonederror_test")
+	assert.Equal(t, err.ReasonPackage(), "github.com/sttk/reasonederror_test")
 	assert.Equal(t, err.Get("Value"), "abc")
 	assert.Nil(t, err.Get("value"))
 	assert.Nil(t, err.Get("Name"))
@@ -75,7 +75,7 @@ func TestNewErr_reasonIsPointer(t *testing.T) {
 	assert.False(t, err.IsOk())
 	assert.True(t, err.IsNotOk())
 	assert.Equal(t, err.ReasonName(), "InvalidValue")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/reasonederror_test")
+	assert.Equal(t, err.ReasonPackage(), "github.com/sttk/reasonederror_test")
 	assert.Equal(t, err.Get("Value"), "abc")
 	assert.Nil(t, err.Get("value"))
 	assert.Nil(t, err.Get("Name"))
@@ -112,7 +112,7 @@ func TestNewErr_withCause(t *testing.T) {
 	assert.False(t, err.IsOk())
 	assert.True(t, err.IsNotOk())
 	assert.Equal(t, err.ReasonName(), "InvalidValue")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/reasonederror_test")
+	assert.Equal(t, err.ReasonPackage(), "github.com/sttk/reasonederror_test")
 	assert.Equal(t, err.Get("Value"), "abc")
 	assert.Nil(t, err.Get("value"))
 	assert.Nil(t, err.Get("Name"))
@@ -151,7 +151,7 @@ func TestNewErr_causeIsAlsoErr(t *testing.T) {
 	assert.False(t, err.IsOk())
 	assert.True(t, err.IsNotOk())
 	assert.Equal(t, err.ReasonName(), "InvalidValue")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/reasonederror_test")
+	assert.Equal(t, err.ReasonPackage(), "github.com/sttk/reasonederror_test")
 
 	assert.Equal(t, err.Get("Value"), "abc")
 	assert.Equal(t, err.Get("Name"), "foo")

--- a/example_err_test.go
+++ b/example_err_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/sttk-go/reasonederror"
+	"github.com/sttk/reasonederror"
 )
 
 func ExampleNewErr() {
@@ -165,7 +165,7 @@ func ExampleErr_ReasonPackage() {
 	fmt.Printf("%v\n", err.ReasonPackage())
 
 	// Output:
-	// github.com/sttk-go/reasonederror_test
+	// github.com/sttk/reasonederror_test
 }
 
 func ExampleErr_Situation() {

--- a/example_notify_test.go
+++ b/example_notify_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/sttk-go/reasonederror"
+	"github.com/sttk/reasonederror"
 )
 
 func ExampleAddAsyncErrHandler() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sttk-go/reasonederror
+module github.com/sttk/reasonederror
 
 go 1.13
 

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
This PR changes import path and repository name of this package.

This package was originally in `sttk-go` project, and that import path and repository path were`github.com/sttk-go/reasonederror`.